### PR TITLE
Add optional taskRoleArn and fallback to existing task definition value

### DIFF
--- a/ecs_deploy.py
+++ b/ecs_deploy.py
@@ -165,6 +165,12 @@ class CLI(object):
             type=int,
             help='Number of Task Definition Revisions to persist before \
                 deregistering oldest revisions.')
+        
+        parser.add_argument(
+            '--task-role-arn',
+            type=str,
+            help='ARN of the IAM role that containers in this task can assume. \
+                If not provided, the existing taskRoleArn will be used.')
 
         args = parser.parse_args(sys.argv[1:])
         return vars(args)
@@ -270,6 +276,13 @@ class CLI(object):
 
             if 'executionRoleArn' in self.task_definition:
                 kwargs['executionRoleArn'] = self.task_definition['executionRoleArn']
+            
+            taskRoleArn = self.args.get('task_role_arn')
+            if taskRoleArn is None:
+                if 'taskRoleArn' in self.task_definition:
+                    kwargs['taskRoleArn'] = self.task_definition['taskRoleArn']
+            else:
+                kwargs['taskRoleArn'] = taskRoleArn
 
             # optional kwargs from args
             for ci in self.args.get('container_image'):


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 data-start="155" data-end="166">🧩 Title</h2>
<p data-start="168" data-end="236"><strong data-start="168" data-end="236">Preserve <code data-start="179" data-end="192">taskRoleArn</code> when registering new ECS task definitions</strong></p>
<hr data-start="238" data-end="241">
<h2 data-start="243" data-end="260">📄 Description</h2>
<h3 data-start="262" data-end="273">Problem</h3>
<p data-start="275" data-end="504">Currently, <code data-start="286" data-end="301">ecs-deploy.py</code> registers a new ECS task definition without preserving the <code data-start="361" data-end="374">taskRoleArn</code>.<br data-start="375" data-end="378">
When deploying a new revision, this causes the task role to be silently removed unless it is manually reconfigured afterwards.</p>
<p data-start="506" data-end="701">This behavior can break applications that rely on IAM permissions (e.g. access to SSM, Secrets Manager, S3), and may introduce security or runtime issues without clear feedback during deployment.</p>
<hr data-start="703" data-end="706">
<h3 data-start="708" data-end="720">Solution</h3>
<p data-start="722" data-end="793">This PR adds safe and backward-compatible support for <code data-start="776" data-end="789">taskRoleArn</code> by:</p>
<ul data-start="795" data-end="1047">
<li data-start="795" data-end="851">
<p data-start="797" data-end="851">Introducing an optional CLI argument <code data-start="834" data-end="851">--task-role-arn</code></p>
</li>
<li data-start="852" data-end="972">
<p data-start="854" data-end="972">Automatically preserving the existing <code data-start="892" data-end="905">taskRoleArn</code> from the current task definition when the argument is not provided</p>
</li>
<li data-start="973" data-end="1047">
<p data-start="975" data-end="1047">Ensuring the task role is correctly passed to <code data-start="1021" data-end="1047">register_task_definition</code></p>
</li>
</ul>
<p data-start="1049" data-end="1166">No existing behavior is changed unless the task definition already has a role or the new argument is explicitly used.</p>
<hr data-start="1168" data-end="1171">
<h3 data-start="1173" data-end="1193">Behavior Summary</h3>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex w-fit flex-col-reverse">
Scenario | Result
-- | --
--task-role-arn provided | Uses the provided role
Argument not provided, role exists | Preserves existing taskRoleArn
Argument not provided, no role exists | Keeps current behavior

</div></div>
<hr data-start="1435" data-end="1438">
<h3 data-start="1440" data-end="1460">Why this matters</h3>
<ul data-start="1462" data-end="1687">
<li data-start="1462" data-end="1522">
<p data-start="1464" data-end="1522">Prevents accidental loss of IAM permissions during deploys</p>
</li>
<li data-start="1523" data-end="1591">
<p data-start="1525" data-end="1591">Improves security posture by avoiding unintended privilege changes</p>
</li>
<li data-start="1592" data-end="1651">
<p data-start="1594" data-end="1651">Aligns deployment behavior with expectations of ECS users</p>
</li>
<li data-start="1652" data-end="1687">
<p data-start="1654" data-end="1687">Keeps full backward compatibility</p>
</li>
</ul>
<hr data-start="1689" data-end="1692">
<h3 data-start="1694" data-end="1711">Compatibility</h3>
<ul data-start="1713" data-end="1803">
<li data-start="1713" data-end="1736">
<p data-start="1715" data-end="1736">✔ No breaking changes</p>
</li>
<li data-start="1737" data-end="1771">
<p data-start="1739" data-end="1771">✔ Works for both EC2 and Fargate</p>
</li>
<li data-start="1772" data-end="1803">
<p data-start="1774" data-end="1803">✔ Safe for existing pipelines</p>
</li>
</ul>
<hr data-start="1805" data-end="1808">
<h3 data-start="1810" data-end="1821">Testing</h3>
<ul data-start="1823" data-end="2035">
<li data-start="1823" data-end="1893">
<p data-start="1825" data-end="1893">Verified that new task definitions retain the original <code data-start="1880" data-end="1893">taskRoleArn</code></p>
</li>
<li data-start="1894" data-end="1974">
<p data-start="1896" data-end="1974">Verified that explicitly passing <code data-start="1929" data-end="1946">--task-role-arn</code> overrides the existing role</p>
</li>
<li data-start="1975" data-end="2035">
<p data-start="1977" data-end="2035">Confirmed that deployments without roles remain unaffected</p></li></ul><!--EndFragment-->
</body>
</html>